### PR TITLE
Potential fix for code scanning alert no. 22: Unvalidated dynamic method call

### DIFF
--- a/plugin/notes/speaker-view.html
+++ b/plugin/notes/speaker-view.html
@@ -401,8 +401,12 @@
 							handleStateMessage( data );
 						}
 						else if( data.type === 'return' ) {
-							pendingCalls[data.callId](data.result);
-							delete pendingCalls[data.callId];
+							if (data.callId in pendingCalls && typeof pendingCalls[data.callId] === 'function') {
+								pendingCalls[data.callId](data.result);
+								delete pendingCalls[data.callId];
+							} else {
+								console.warn('Invalid callId or non-function reference in pendingCalls:', data.callId);
+							}
 						}
 					}
 					// Messages sent by the reveal.js inside of the current slide preview


### PR DESCRIPTION
Potential fix for [https://github.com/JacOng17/legacy/security/code-scanning/22](https://github.com/JacOng17/legacy/security/code-scanning/22)

To fix the issue, we need to validate `data.callId` before using it to access `pendingCalls`. Specifically:
1. Check if `data.callId` exists as a key in `pendingCalls` using `hasOwnProperty` or `in`.
2. Ensure that the value retrieved from `pendingCalls[data.callId]` is a function before invoking it.
3. If the validation fails, handle the error gracefully (e.g., log a warning or ignore the message).

This approach ensures that only valid and expected function calls are executed, mitigating the risk of runtime exceptions or malicious exploitation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
