### PR TITLE
Potential fix for code scanning alert no. 31: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -2,6 +2,9 @@ name: tests
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/JacOng17/legacy/security/code-scanning/31](https://github.com/JacOng17/legacy/security/code-scanning/31)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only performs read operations (e.g., checking out the repository and running tests), we will set `contents: read` as the minimal required permission. This ensures that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
