### PR TITLE
Potential fix for code scanning alert no. 32: Unsafe HTML constructed from library input

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -738,15 +738,22 @@ export default function( revealElement, options ) {
 		dom.overlay.innerHTML =
 			`<header>
 				<a class="close" href="#"><span class="icon"></span></a>
-				<a class="external" href="${url}" target="_blank"><span class="icon"></span></a>
+				<a class="external" target="_blank"><span class="icon"></span></a>
 			</header>
 			<div class="spinner"></div>
 			<div class="viewport">
-				<iframe src="${url}"></iframe>
+				<iframe></iframe>
 				<small class="viewport-inner">
 					<span class="x-frame-error">Unable to load iframe. This is likely due to the site's policy (x-frame-options).</span>
 				</small>
 			</div>`;
+
+		// Safely set the href and src attributes
+		const externalLink = dom.overlay.querySelector('.external');
+		externalLink.setAttribute('href', url);
+
+		const iframe = dom.overlay.querySelector('iframe');
+		iframe.setAttribute('src', url);
 
 		dom.overlay.querySelector( 'iframe' ).addEventListener( 'load', event => {
 			dom.overlay.classList.add( 'loaded' );


### PR DESCRIPTION
Potential fix for [https://github.com/JacOng17/legacy/security/code-scanning/32](https://github.com/JacOng17/legacy/security/code-scanning/32)

To fix the issue, we need to ensure that the `url` parameter is sanitized or validated before being used in the HTML construction. The best approach is to avoid directly interpolating the `url` into the HTML string. Instead, we can use DOM manipulation methods to safely set the `href` attribute of the anchor element. This avoids the use of `innerHTML` and ensures that the `url` is treated as plain text rather than executable HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
