### PR TITLE
Potential fix for code scanning alert no. 33: Unsafe HTML constructed from library input

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -735,18 +735,39 @@ export default function( revealElement, options ) {
 		dom.overlay.classList.add( 'overlay-preview' );
 		dom.wrapper.appendChild( dom.overlay );
 
-		dom.overlay.innerHTML =
-			`<header>
-				<a class="close" href="#"><span class="icon"></span></a>
-				<a class="external" href="${url}" target="_blank"><span class="icon"></span></a>
-			</header>
-			<div class="spinner"></div>
-			<div class="viewport">
-				<iframe src="${url}"></iframe>
-				<small class="viewport-inner">
-					<span class="x-frame-error">Unable to load iframe. This is likely due to the site's policy (x-frame-options).</span>
-				</small>
-			</div>`;
+		const header = document.createElement('header');
+		const closeLink = document.createElement('a');
+		closeLink.className = 'close';
+		closeLink.href = '#';
+		closeLink.innerHTML = '<span class="icon"></span>';
+		header.appendChild(closeLink);
+
+		const externalLink = document.createElement('a');
+		externalLink.className = 'external';
+		externalLink.href = url;
+		externalLink.target = '_blank';
+		externalLink.innerHTML = '<span class="icon"></span>';
+		header.appendChild(externalLink);
+
+		dom.overlay.appendChild(header);
+
+		const spinner = document.createElement('div');
+		spinner.className = 'spinner';
+		dom.overlay.appendChild(spinner);
+
+		const viewport = document.createElement('div');
+		viewport.className = 'viewport';
+
+		const iframe = document.createElement('iframe');
+		iframe.src = url;
+		viewport.appendChild(iframe);
+
+		const viewportInner = document.createElement('small');
+		viewportInner.className = 'viewport-inner';
+		viewportInner.innerHTML = '<span class="x-frame-error">Unable to load iframe. This is likely due to the site\'s policy (x-frame-options).</span>';
+		viewport.appendChild(viewportInner);
+
+		dom.overlay.appendChild(viewport);
 
 		dom.overlay.querySelector( 'iframe' ).addEventListener( 'load', event => {
 			dom.overlay.classList.add( 'loaded' );


### PR DESCRIPTION
Potential fix for [https://github.com/JacOng17/legacy/security/code-scanning/33](https://github.com/JacOng17/legacy/security/code-scanning/33)

To fix the issue, the `url` parameter should be sanitized or validated before being interpolated into the HTML string. This can be achieved by using a library like `DOMPurify` to sanitize the `url` or by ensuring that the `url` is properly encoded to prevent injection attacks. Alternatively, the HTML construction can be refactored to use safer DOM manipulation methods, such as creating elements programmatically and setting their attributes explicitly.

The best approach here is to use DOM manipulation methods to construct the HTML safely. This avoids the use of `innerHTML` and ensures that the `url` is treated as a plain string rather than executable code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
