### PR TITLE
Potential fix for code scanning alert no. 34: DOM text reinterpreted as HTML

### DIFF
--- a/js/controllers/slidecontent.js
+++ b/js/controllers/slidecontent.js
@@ -7,6 +7,15 @@ import fitty from 'fitty';
  * Handles loading, unloading and playback of slide
  * content such as images, videos and iframes.
  */
+function isValidUrl(url) {
+    try {
+        const parsedUrl = new URL(url);
+        return parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:';
+    } catch (e) {
+        return false;
+    }
+}
+
 export default class SlideContent {
 
 	constructor( Reveal ) {
@@ -52,7 +61,12 @@ export default class SlideContent {
 		// Media elements with data-src attributes
 		queryAll( slide, 'img[data-src], video[data-src], audio[data-src], iframe[data-src]' ).forEach( element => {
 			if( element.tagName !== 'IFRAME' || this.shouldPreload( element ) ) {
-				element.setAttribute( 'src', element.getAttribute( 'data-src' ) );
+				const dataSrc = element.getAttribute( 'data-src' );
+				if (isValidUrl(dataSrc)) {
+					element.setAttribute( 'src', dataSrc );
+				} else {
+					console.warn('Invalid data-src URL:', dataSrc);
+				}
 				element.setAttribute( 'data-lazy-loaded', '' );
 				element.removeAttribute( 'data-src' );
 			}


### PR DESCRIPTION
Potential fix for [https://github.com/JacOng17/legacy/security/code-scanning/34](https://github.com/JacOng17/legacy/security/code-scanning/34)

To fix the issue, we need to ensure that the value of `data-src` is sanitized or validated before assigning it to the `src` attribute. A simple and effective approach is to use a URL validation function to ensure that the `data-src` value is a valid and safe URL. This prevents malicious scripts or invalid inputs from being used.

1. Add a utility function to validate URLs. This function should check if the URL is well-formed and belongs to a trusted domain (if applicable).
2. Before assigning the `data-src` value to the `src` attribute, validate it using the utility function.
3. If the value is invalid, skip the assignment or log an error.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
