### PR TITLE
Potential fix for code scanning alert no. 44: DOM text reinterpreted as HTML

### DIFF
--- a/js/controllers/slidecontent.js
+++ b/js/controllers/slidecontent.js
@@ -1,5 +1,6 @@
 import { extend, queryAll, closest, getMimeTypeFromFile } from '../utils/util.js'
 import { isMobile } from '../utils/device.js'
+import DOMPurify from 'dompurify';
 
 import fitty from 'fitty';
 
@@ -63,7 +64,8 @@ export default class SlideContent {
 			if( element.tagName !== 'IFRAME' || this.shouldPreload( element ) ) {
 				const dataSrc = element.getAttribute( 'data-src' );
 				if (isValidUrl(dataSrc)) {
-					element.setAttribute( 'src', dataSrc );
+					const sanitizedSrc = DOMPurify.sanitize(dataSrc);
+					element.setAttribute( 'src', sanitizedSrc );
 				} else {
 					console.warn('Invalid data-src URL:', dataSrc);
 				}

--- a/package.json
+++ b/package.json
@@ -96,5 +96,8 @@
       "no-eq-null": 2,
       "no-unused-expressions": 0
     }
+  },
+  "dependencies": {
+    "dompurify": "^3.2.6"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/JacOng17/legacy/security/code-scanning/44](https://github.com/JacOng17/legacy/security/code-scanning/44)

To fix the issue, the `dataSrc` value should be sanitized or escaped before being used as the `src` attribute. This ensures that any potentially malicious content in the `data-src` attribute is neutralized. A safe approach is to use a library like `DOMPurify` to sanitize the URL or escape it using contextual encoding.

The best way to fix the problem is:
1. Import a library like `DOMPurify` to sanitize the `dataSrc` value.
2. Apply sanitization to the `dataSrc` value before setting it as the `src` attribute.
3. Ensure that the sanitization process does not alter valid URLs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
