### PR TITLE
Potential fix for code scanning alert no. 35: DOM text reinterpreted as HTML

### DIFF
--- a/js/controllers/slidecontent.js
+++ b/js/controllers/slidecontent.js
@@ -79,7 +79,13 @@ export default class SlideContent {
 			let sources = 0;
 
 			queryAll( media, 'source[data-src]' ).forEach( source => {
-				source.setAttribute( 'src', source.getAttribute( 'data-src' ) );
+				const dataSrc = source.getAttribute( 'data-src' );
+				if (isValidUrl(dataSrc)) {
+					const sanitizedSrc = DOMPurify.sanitize(dataSrc);
+					source.setAttribute( 'src', sanitizedSrc );
+				} else {
+					console.warn('Invalid data-src URL on <source>:', dataSrc);
+				}
 				source.removeAttribute( 'data-src' );
 				source.setAttribute( 'data-lazy-loaded', '' );
 				sources += 1;


### PR DESCRIPTION
Potential fix for [https://github.com/JacOng17/legacy/security/code-scanning/35](https://github.com/JacOng17/legacy/security/code-scanning/35)

To fix the issue, add the same safety checks applied to other resources:
- Extract the value of `data-src` from each `<source>` element.
- Use `isValidUrl` to ensure the value is an HTTP(S) URL.
- Sanitize it with `DOMPurify.sanitize` before using it as the value for the `src` attribute.
- If the value is not valid, optionally log a warning instead of setting the `src` attribute.
These changes should be applied in the `load` method (lines 81-86) in js/controllers/slidecontent.js.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
